### PR TITLE
fix: stub copy path

### DIFF
--- a/src/Console/InstallHookCommand.php
+++ b/src/Console/InstallHookCommand.php
@@ -26,7 +26,7 @@ class InstallHookCommand extends Command
     public function handle(): int
     {
         $hookPath = $this->argument('hookPath') ?? base_path('.git/hooks/commit-msg');
-        $stubPath = $this->argument('stubPath') ?? (__DIR__ . '/../src/Hooks/commit-msg');
+        $stubPath = $this->argument('stubPath') ?? (__DIR__ . '/../Hooks/commit-msg');
 
         $hooksDir = \dirname($hookPath);
         if (!$this->files->exists($hooksDir)) {


### PR DESCRIPTION
This pull request includes a minor fix to the `InstallHookCommand` class. The change corrects the file path for the `stubPath` argument to ensure it points to the correct directory.

* [`src/Console/InstallHookCommand.php`](diffhunk://#diff-5d89208db5199d01741410b3274e723085c1b35784b745620f4a3a8d57bc582aL29-R29): Updated the default `stubPath` value to fix the directory path from `'/../src/Hooks/commit-msg'` to `'/../Hooks/commit-msg'`.